### PR TITLE
Add mood tracker bot scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-VIBECODING
+# Mood Tracker Bot
+
+Телеграм-бот для ежедневного трекинга эмоций.
+
+Для запуска установите зависимости и укажите токен бота в переменной окружения `BOT_TOKEN`.
+
+```
+pip install aiogram aiosqlite apscheduler
+python main.py
+```

--- a/database.py
+++ b/database.py
@@ -1,0 +1,51 @@
+import aiosqlite
+from datetime import date
+
+DB_PATH = 'mood.db'
+
+CREATE_EVENTS_TABLE = '''
+CREATE TABLE IF NOT EXISTS events(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    event_date TEXT,
+    description TEXT,
+    emotion TEXT,
+    rating INTEGER
+)'''
+
+async def init_db():
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(CREATE_EVENTS_TABLE)
+        await db.commit()
+
+async def add_event(user_id: int, event_date: str, description: str, emotion: str, rating: int):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            'INSERT INTO events(user_id, event_date, description, emotion, rating) VALUES (?,?,?,?,?)',
+            (user_id, event_date, description, emotion, rating)
+        )
+        await db.commit()
+
+async def update_event(user_id: int, event_date: str, description: str, emotion: str, rating: int):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            'UPDATE events SET description=?, emotion=?, rating=? WHERE user_id=? AND event_date=?',
+            (description, emotion, rating, user_id, event_date)
+        )
+        await db.commit()
+
+async def get_events_between(user_id: int, start: str, end: str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            'SELECT event_date, description, emotion, rating FROM events WHERE user_id=? AND event_date BETWEEN ? AND ? ORDER BY event_date',
+            (user_id, start, end)
+        ) as cur:
+            return await cur.fetchall()
+
+async def get_best_event(user_id: int, start: str, end: str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            'SELECT event_date, description, emotion, rating FROM events WHERE user_id=? AND event_date BETWEEN ? AND ? ORDER BY rating DESC LIMIT 1',
+            (user_id, start, end)
+        ) as cur:
+            return await cur.fetchone()

--- a/handlers.py
+++ b/handlers.py
@@ -1,0 +1,97 @@
+from aiogram import Router, F
+from aiogram.types import Message
+from aiogram.fsm.state import StatesGroup, State
+from aiogram.fsm.context import FSMContext
+from aiogram.utils.formatting import as_marked_section, Bold
+from datetime import datetime, timedelta
+import database as db
+
+router = Router()
+
+class EventState(StatesGroup):
+    description = State()
+    emotion = State()
+    rating = State()
+
+@router.message(F.text == '📌 Добавить событие дня')
+async def cmd_add_event(message: Message, state: FSMContext):
+    await state.update_data(edit=False)
+    await state.set_state(EventState.description)
+    await message.answer('Опишите главное событие дня:')
+
+@router.message(F.text == '✏️ Изменить событие дня')
+async def cmd_edit_event(message: Message, state: FSMContext):
+    await state.update_data(edit=True)
+    await state.set_state(EventState.description)
+    await message.answer('Введите новое описание события:')
+
+@router.message(EventState.description)
+async def event_description(message: Message, state: FSMContext):
+    await state.update_data(description=message.text)
+    await state.set_state(EventState.emotion)
+    await message.answer('Какую эмоцию вы испытали?')
+
+@router.message(EventState.emotion)
+async def event_emotion(message: Message, state: FSMContext):
+    await state.update_data(emotion=message.text)
+    await state.set_state(EventState.rating)
+    await message.answer('Оцените эмоцию от 1 до 10:')
+
+@router.message(EventState.rating)
+async def event_rating(message: Message, state: FSMContext):
+    data = await state.update_data(rating=int(message.text))
+    today = datetime.now().date().isoformat()
+    if data.get('edit'):
+        await db.update_event(
+            user_id=message.from_user.id,
+            event_date=today,
+            description=data['description'],
+            emotion=data['emotion'],
+            rating=data['rating']
+        )
+        text = 'Событие обновлено!'
+    else:
+        await db.add_event(
+            user_id=message.from_user.id,
+            event_date=today,
+            description=data['description'],
+            emotion=data['emotion'],
+            rating=data['rating']
+        )
+        text = 'Событие сохранено!'
+    await state.clear()
+    await message.answer(text)
+
+@router.message(F.text == '📆 Посмотреть события недели')
+async def view_week(message: Message):
+    end = datetime.now().date()
+    start = end - timedelta(days=6)
+    rows = await db.get_events_between(message.from_user.id, start.isoformat(), end.isoformat())
+    if not rows:
+        await message.answer('Событий нет')
+        return
+    text = as_marked_section(*[
+        Bold(r[0]) + f" {r[1]} - {r[2]} ({r[3]}/10)" for r in rows
+    ], marker='\n')
+    await message.answer(text.as_html())
+
+@router.message(F.text == '🌟 Посмотреть лучшие события недели')
+async def best_week(message: Message):
+    end = datetime.now().date()
+    start = end - timedelta(days=6)
+    row = await db.get_best_event(message.from_user.id, start.isoformat(), end.isoformat())
+    if not row:
+        await message.answer('Событий нет')
+        return
+    await message.answer(f"{row[0]} {row[1]} - {row[2]} ({row[3]}/10)")
+
+@router.message(F.text == '🏆 Посмотреть лучшие события месяца')
+async def best_month(message: Message):
+    end = datetime.now().date()
+    start = end - timedelta(days=30)
+    row = await db.get_best_event(message.from_user.id, start.isoformat(), end.isoformat())
+    if not row:
+        await message.answer('Событий нет')
+        return
+    await message.answer(f"{row[0]} {row[1]} - {row[2]} ({row[3]}/10)")
+

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,0 +1,14 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+main_kb = ReplyKeyboardMarkup(resize_keyboard=True)
+main_kb.add(
+    KeyboardButton('📌 Добавить событие дня'),
+    KeyboardButton('✏️ Изменить событие дня'),
+)
+main_kb.add(
+    KeyboardButton('📆 Посмотреть события недели'),
+    KeyboardButton('🌟 Посмотреть лучшие события недели'),
+)
+main_kb.add(
+    KeyboardButton('🏆 Посмотреть лучшие события месяца')
+)

--- a/main.py
+++ b/main.py
@@ -1,16 +1,35 @@
-# This is a sample Python script.
+import asyncio
+import os
 
-# Press ⌃R to execute it or replace it with your code.
-# Press Double ⇧ to search everywhere for classes, files, tool windows, actions, and settings.
+from aiogram import Bot, Dispatcher
+from aiogram import types
+from aiogram.fsm.storage.memory import MemoryStorage
 
+import database as db
+import handlers
+from scheduler import create_scheduler
+from keyboards import main_kb
 
-def print_hi(name):
-    # Use a breakpoint in the code line below to debug your script.
-    print(f'Hi, {name}')  # Press ⌘F8 to toggle the breakpoint.
+BOT_TOKEN = os.getenv('BOT_TOKEN')
 
+async def main() -> None:
+    await db.init_db()
 
-# Press the green button in the gutter to run the script.
+    bot = Bot(BOT_TOKEN, parse_mode='HTML')
+    bot.owner_id = (await bot.get_me()).id
+
+    dp = Dispatcher(storage=MemoryStorage())
+    dp.include_router(handlers.router)
+
+    scheduler = create_scheduler(bot)
+    scheduler.start()
+
+    @dp.message(commands=['start'])
+    async def cmd_start(message: types.Message):
+        await message.answer('Привет! Я бот для трекинга эмоций.', reply_markup=main_kb)
+
+    await dp.start_polling(bot)
+
 if __name__ == '__main__':
-    print_hi('PyCharm')
+    asyncio.run(main())
 
-# See PyCharm help at https://www.jetbrains.com/help/pycharm/

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,29 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from datetime import datetime
+
+
+def create_scheduler(bot):
+    scheduler = AsyncIOScheduler(timezone="UTC")
+
+    # Daily at 20:00 UTC
+    scheduler.add_job(
+        lambda: bot.send_message(chat_id=bot.owner_id,
+                                 text="Опишите главное событие дня, эмоцию и оцените ее от 1 до 10"),
+        'cron', hour=20, minute=0
+    )
+
+    # Weekly on Sunday at 20:00 UTC
+    scheduler.add_job(
+        lambda: bot.send_message(chat_id=bot.owner_id,
+                                 text="Какая из эмоций недели была самой яркой?"),
+        'cron', day_of_week='sun', hour=20, minute=0
+    )
+
+    # Monthly on the 1st at 20:00 UTC
+    scheduler.add_job(
+        lambda: bot.send_message(chat_id=bot.owner_id,
+                                 text="Какая из эмоций месяца была самой запоминающейся?"),
+        'cron', day=1, hour=20, minute=0
+    )
+
+    return scheduler


### PR DESCRIPTION
## Summary
- set up README instructions
- implement asynchronous SQLite helpers
- add scheduler for daily/weekly/monthly prompts
- create keyboard markup with main actions
- implement bot handlers and start script

## Testing
- `python -m py_compile main.py handlers.py database.py scheduler.py keyboards.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a2fde0708326a5e65469016ff121